### PR TITLE
remove intl dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   flutter:
     sdk: flutter
   dio: '>=5.0.0'
-  intl: ^0.18.0
   fixnum: ^1.1.0
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I've recently ran over a dependency conflict coming from this dependency:
```
Because no versions of flutter_osm_web match >1.0.0-dev.3 <1.0.1 and flutter_osm_plugin 1.0.0-dev.4 depends on flutter_osm_web >=1.0.0-dev.3 <1.0.1, flutter_osm_plugin 1.0.0-dev.4 requires flutter_osm_web 1.0.0-dev.3.
And because flutter_osm_web 1.0.0-dev.3 depends on routing_client_dart ^0.5.3, flutter_osm_plugin 1.0.0-dev.4 requires routing_client_dart ^0.5.3.
Because routing_client_dart 0.5.3 depends on intl ^0.18.0 and no versions of routing_client_dart match >0.5.3 <0.6.0, routing_client_dart ^0.5.3 requires intl ^0.18.0.
Thus, flutter_osm_plugin 1.0.0-dev.4 requires intl ^0.18.0.
```

I've searched through the source code but there doesn't seem to be any usage of intl anyway so I removed it. If there is use that I've missed, please let me know 😄 