### PR TITLE
Bugfix - Response parsing when the 'overview' parameter is set to 'none'

### DIFF
--- a/lib/src/models/road.dart
+++ b/lib/src/models/road.dart
@@ -53,7 +53,7 @@ class Road {
         polylineEncoded = route["geometry"].runtimeType == String
             ? route["geometry"] as String
             : null {
-    if (route["geometry"].runtimeType != String) {
+    if (route["geometry"].runtimeType != String && null != route["geometry"]) {
       final List<List<dynamic>> listOfPoints =
           List.castFrom(route["geometry"]["coordinates"]);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,13 +10,13 @@ dependencies:
   flutter:
     sdk: flutter
   dio: '>=5.0.0'
-  intl: ^0.18.0
+  intl: ^0.19.0
   fixnum: ^1.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
-  http_mock_adapter: ^0.4.2
+  flutter_lints: ^3.0.1
+  http_mock_adapter: ^0.6.1
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/test/osrm_dart_test.dart
+++ b/test/osrm_dart_test.dart
@@ -949,7 +949,8 @@ void main() {
 
     final instructions = await roadManager.buildInstructions(road);
 
-    final currentLocation = LngLat.fromList(lnglat: [13.389147, 52.527549]);
+    final currentLocation = LngLat.fromList(lnglat: [13.389147, 52.527549])
+        .alignWithPrecision(precision: 5);
     final turnByTurnInformation = await roadManager
         .nextInstruction(instructions, road, currentLocation, tolerance: 5);
     //You have arrived at your {nth} destination, on the right

--- a/test/osrm_dart_test.dart
+++ b/test/osrm_dart_test.dart
@@ -72,6 +72,7 @@ void main() {
 
       expect(road.distance.toStringAsFixed(2), 4.7338.toStringAsFixed(2));
       expect(road.duration >= 615.0, true);
+      expect(road.polylineEncoded != null, true);
     });
     test("test get road without steps", () async {
       List<LngLat> waypoints = [
@@ -90,6 +91,29 @@ void main() {
       );
       expect(
           road.roadLegs.where((element) => element.isNotEmpty).isEmpty, true);
+    });
+    test("test get road without overview geometry", () async {
+      List<LngLat> waypoints = [
+        LngLat(lng: 13.388860, lat: 52.517037),
+        LngLat(lng: 13.397634, lat: 52.529407),
+        LngLat(lng: 13.428555, lat: 52.523219),
+      ];
+      dioAdapter.onGet(
+        "https://routing.openstreetmap.de/routed-car/route/v1/driving/13.38886,52.517037;13.397634,52.529407;13.428555,52.523219?steps=true&overview=false&geometries=polyline&alternatives=false",
+        (server) => server.reply(200, _responseWithoutGeometry),
+      );
+      final road = await manager.getRoad(
+        waypoints: waypoints,
+        geometries: Geometries.polyline,
+        steps: true,
+        language: Languages.en,
+        overview: Overview.none,
+      );
+
+      expect(road.distance.toStringAsFixed(2), 4.7338.toStringAsFixed(2));
+      expect(road.duration >= 615.0, true);
+      expect(road.polyline, null);
+      expect(road.polylineEncoded, null);
     });
     test("test if polyline not null when geometry is geojson", () async {
       List<LngLat> waypoints = [
@@ -135,6 +159,31 @@ void main() {
       );
       expect(road.distance >= 7.9822, true);
       expect(road.duration >= 945.6, true);
+      expect(road.polylineEncoded != null, true);
+    });
+    test("test get trip without overview geometry", () async {
+      List<LngLat> waypoints = [
+        LngLat(lng: 13.388860, lat: 52.517037),
+        LngLat(lng: 13.397634, lat: 52.529407),
+        LngLat(lng: 13.428555, lat: 52.523219),
+      ];
+      dioAdapter.onGet(
+        "https://routing.openstreetmap.de/routed-car/trip/v1/driving/13.38886,52.517037;13.397634,52.529407;13.428555,52.523219?steps=false&overview=false&geometries=polyline&source=first&destination=last&roundtrip=true",
+        (server) => server.reply(200, _responseTripWithoutGeometry),
+      );
+      final road = await manager.getTrip(
+        waypoints: waypoints,
+        destination: DestinationGeoPointOption.last,
+        source: SourceGeoPointOption.first,
+        geometries: Geometries.polyline,
+        steps: false,
+        language: Languages.en,
+        overview: Overview.none,
+      );
+      expect(road.distance >= 7.9822, true);
+      expect(road.duration >= 945.6, true);
+      expect(road.polyline, null);
+      expect(road.polylineEncoded, null);
     });
   });
   test("test parser", () async {
@@ -812,6 +861,682 @@ void main() {
     ));
     expect(road.distance, 4.7238);
     expect(road.duration, 615.0);
+  });
+  test("test parser without overview geometry", () async {
+    final responseApi = {
+      "code": "Ok",
+      "waypoints": [
+        {
+          "hint":
+              "GTPviIxQ4IAYAAAABQAAAAAAAAAgAAAASjFaQdLNK0AAAAAAsPePQQwAAAADAAAAAAAAABAAAAAi5QAA_kvMAKlYIQM8TMwArVghAwAA7wo6xQgq",
+          "distance": 4.231666,
+          "location": [13.388798, 52.517033],
+          "name": "Friedrichstraße"
+        },
+        {
+          "hint":
+              "T88igL3b-IgGAAAACgAAAAAAAAB2AAAAW7-PQOKcyEAAAAAApq6DQgYAAAAKAAAAAAAAAHYAAAAi5QAAf27MABiJIQOCbswA_4ghAwAAXwU6xQgq",
+          "distance": 2.789393,
+          "location": [13.397631, 52.529432],
+          "name": "Torstraße"
+        },
+        {
+          "hint":
+              "bswigP___38fAAAAUQAAACYAAAAeAAAAsowKQkpQX0Lx6yZCvsQGQh8AAABRAAAAJgAAAB4AAAAi5QAASufMAOdwIQNL58wA03AhAwMAvxA6xQgq",
+          "distance": 2.226595,
+          "location": [13.428554, 52.523239],
+          "name": "Platz der Vereinten Nationen"
+        }
+      ],
+      "routes": [
+        {
+          "legs": [
+            {
+              "steps": [
+                {
+                  "intersections": [
+                    {
+                      "out": 0,
+                      "entry": [true],
+                      "location": [13.388798, 52.517033],
+                      "bearings": [355]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, false, false, true],
+                      "location": [13.388779, 52.517155],
+                      "bearings": [0, 90, 180, 270]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false, true],
+                      "location": [13.388643, 52.518027],
+                      "bearings": [0, 90, 180, 270]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false, true, false],
+                      "location": [13.388544, 52.518716],
+                      "bearings": [30, 90, 180, 270, 315]
+                    },
+                    {
+                      "out": 0,
+                      "in": 1,
+                      "entry": [true, false, true],
+                      "location": [13.388308, 52.520336],
+                      "bearings": [0, 180, 270]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false, true],
+                      "location": [13.388024, 52.52175],
+                      "bearings": [0, 60, 180, 225]
+                    },
+                    {
+                      "out": 0,
+                      "in": 1,
+                      "entry": [true, false, true],
+                      "location": [13.387885, 52.522524],
+                      "bearings": [0, 180, 225]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false],
+                      "location": [13.387799, 52.523401],
+                      "bearings": [0, 90, 180]
+                    },
+                    {
+                      "out": 0,
+                      "in": 1,
+                      "lanes": [
+                        {
+                          "valid": false,
+                          "indications": ["none"]
+                        },
+                        {
+                          "valid": false,
+                          "indications": ["left"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight"]
+                        }
+                      ],
+                      "entry": [true, false, true],
+                      "location": [13.387748, 52.523877],
+                      "bearings": [0, 180, 270]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false],
+                      "location": [13.3877, 52.524433],
+                      "bearings": [0, 90, 180]
+                    },
+                    {
+                      "out": 3,
+                      "in": 1,
+                      "entry": [true, false, false, true],
+                      "location": [13.387337, 52.526239],
+                      "bearings": [105, 165, 300, 345]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, false, false, false],
+                      "location": [13.387283, 52.526386],
+                      "bearings": [0, 105, 165, 255]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry":
+                      "mfp_I__vpAYBO@K@[BuBRgBLK@UBMMC?AAKAe@FyBTC@E?IDKDA@K@]BUBSBA?E@E@A@KFUBK@mAL{CZQ@qBRUBmAFc@@}@Fu@DG?a@B[@qAF_AJ[D_E`@SBO@ODA@UDA?]JC?uBNE?OAKA",
+                  "duration": 129.2,
+                  "distance": 1135.7,
+                  "name": "Friedrichstraße",
+                  "weight": 130.4,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 355,
+                    "bearing_before": 0,
+                    "type": "depart",
+                    "location": [13.388798, 52.517033]
+                  }
+                },
+                {
+                  "intersections": [
+                    {
+                      "out": 0,
+                      "in": 1,
+                      "entry": [true, false, true, true],
+                      "location": [13.387215, 52.527166],
+                      "bearings": [75, 180, 255, 330]
+                    },
+                    {
+                      "out": 0,
+                      "in": 1,
+                      "entry": [true, false, true],
+                      "location": [13.389147, 52.527549],
+                      "bearings": [75, 255, 345]
+                    },
+                    {
+                      "out": 0,
+                      "in": 1,
+                      "entry": [true, false, true],
+                      "location": [13.391396, 52.528032],
+                      "bearings": [75, 255, 330]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false],
+                      "location": [13.392425, 52.528233],
+                      "bearings": [75, 165, 255]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false, true],
+                      "location": [13.393814, 52.528526],
+                      "bearings": [75, 135, 255, 315]
+                    },
+                    {
+                      "out": 0,
+                      "in": 1,
+                      "entry": [true, false, true],
+                      "location": [13.395724, 52.528996],
+                      "bearings": [75, 255, 345]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false, true],
+                      "location": [13.397565, 52.529429],
+                      "bearings": [90, 180, 255, 345]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry":
+                      "yer_IcuupACa@AI]mCCUE[AK[iCWqB[{Bk@sE_@_DAICSAOIm@AIQuACOQyAG[Gc@]wBw@aFKu@y@oFCMAOIm@?K",
+                  "duration": 122.3,
+                  "distance": 749,
+                  "name": "Torstraße",
+                  "weight": 122.3,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 71,
+                    "location": [13.387215, 52.527166],
+                    "type": "turn",
+                    "bearing_before": 4,
+                    "modifier": "right"
+                  }
+                },
+                {
+                  "intersections": [
+                    {
+                      "in": 0,
+                      "entry": [true],
+                      "location": [13.397631, 52.529432],
+                      "bearings": [266]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry": "}sr_IevwpA",
+                  "duration": 0,
+                  "distance": 0,
+                  "name": "Torstraße",
+                  "weight": 0,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 0,
+                    "bearing_before": 86,
+                    "type": "arrive",
+                    "location": [13.397631, 52.529432]
+                  }
+                }
+              ],
+              "weight": 252.7,
+              "distance": 1884.7,
+              "summary": "Friedrichstraße, Torstraße",
+              "duration": 251.5
+            },
+            {
+              "steps": [
+                {
+                  "intersections": [
+                    {
+                      "out": 0,
+                      "entry": [true],
+                      "location": [13.397631, 52.529432],
+                      "bearings": [85]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "lanes": [
+                        {
+                          "valid": true,
+                          "indications": ["left"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight", "right"]
+                        }
+                      ],
+                      "entry": [true, true, false, false],
+                      "location": [13.401337, 52.529605],
+                      "bearings": [90, 165, 270, 345]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, false, true],
+                      "location": [13.401541, 52.529618],
+                      "bearings": [90, 165, 285]
+                    },
+                    {
+                      "out": 1,
+                      "in": 3,
+                      "lanes": [
+                        {
+                          "valid": false,
+                          "indications": ["left"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight", "right"]
+                        }
+                      ],
+                      "entry": [true, true, true, false],
+                      "location": [13.409405, 52.528711],
+                      "bearings": [30, 105, 210, 285]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "lanes": [
+                        {
+                          "valid": true,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight", "right"]
+                        }
+                      ],
+                      "entry": [true, true, false],
+                      "location": [13.409967, 52.528591],
+                      "bearings": [105, 165, 285]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "lanes": [
+                        {
+                          "valid": true,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight", "right"]
+                        }
+                      ],
+                      "entry": [true, false, false, false],
+                      "location": [13.410145, 52.528553],
+                      "bearings": [105, 150, 285, 330]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false],
+                      "location": [13.411852, 52.528201],
+                      "bearings": [120, 210, 285]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry":
+                      "}sr_IevwpAAQ?KIuDQmHE}BBQ?Q?OCq@?I?IASAg@OuF?OAi@?c@@c@Du@r@cH@U@I@G@K?E~@kJRyBf@uE@KFi@RaBBMFc@Da@@ETaC@QJ{@Ny@Ha@RiAfBuJF]DOh@yAHSf@aADIR_@",
+                  "duration": 202.6,
+                  "distance": 1272.3,
+                  "name": "Torstraße",
+                  "weight": 202.6,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 85,
+                    "bearing_before": 0,
+                    "type": "depart",
+                    "location": [13.397631, 52.529432]
+                  }
+                },
+                {
+                  "intersections": [
+                    {
+                      "out": 1,
+                      "in": 3,
+                      "lanes": [
+                        {
+                          "valid": false,
+                          "indications": ["left"]
+                        },
+                        {
+                          "valid": false,
+                          "indications": ["left"]
+                        },
+                        {
+                          "valid": false,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight", "right"]
+                        }
+                      ],
+                      "entry": [false, true, true, false],
+                      "location": [13.415405, 52.526922],
+                      "bearings": [30, 135, 210, 315]
+                    },
+                    {
+                      "out": 0,
+                      "in": 3,
+                      "lanes": [
+                        {
+                          "valid": true,
+                          "indications": ["left"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["left"]
+                        },
+                        {
+                          "valid": false,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": false,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": false,
+                          "indications": ["straight"]
+                        }
+                      ],
+                      "entry": [true, true, false, false],
+                      "location": [13.415657, 52.52677],
+                      "bearings": [30, 135, 210, 315]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry": "gdr_Iie{pA\\q@w@y@",
+                  "duration": 12,
+                  "distance": 60.5,
+                  "name": "",
+                  "weight": 12,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 133,
+                    "location": [13.415405, 52.526922],
+                    "type": "turn",
+                    "bearing_before": 133,
+                    "modifier": "left"
+                  }
+                },
+                {
+                  "intersections": [
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "lanes": [
+                        {
+                          "valid": false,
+                          "indications": ["left"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight"]
+                        }
+                      ],
+                      "entry": [true, false, false, true],
+                      "location": [13.415945, 52.527047],
+                      "bearings": [30, 120, 210, 315]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry": "aer_Iuh{pAe@a@CCUQaCkB{@y@GESO",
+                  "duration": 18.2,
+                  "distance": 177.4,
+                  "name": "Prenzlauer Allee",
+                  "weight": 18.2,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 26,
+                    "location": [13.415945, 52.527047],
+                    "type": "new name",
+                    "bearing_before": 30,
+                    "modifier": "straight"
+                  }
+                },
+                {
+                  "intersections": [
+                    {
+                      "out": 1,
+                      "in": 2,
+                      "entry": [true, true, false, false],
+                      "location": [13.417166, 52.528458],
+                      "bearings": [30, 90, 210, 315]
+                    },
+                    {
+                      "out": 1,
+                      "in": 3,
+                      "entry": [false, true, true, false],
+                      "location": [13.423592, 52.528206],
+                      "bearings": [45, 120, 225, 285]
+                    },
+                    {
+                      "out": 1,
+                      "in": 3,
+                      "entry": [true, true, false, false],
+                      "location": [13.423868, 52.528136],
+                      "bearings": [45, 120, 210, 300]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry":
+                      "{mr_Iip{pA?_@?C?[IoCIgDMsEAYOkEAQ@Yj@kENg@ZyBBIHm@FY@GBUJk@JmA?c@?QAQG]",
+                  "duration": 55,
+                  "distance": 547.1,
+                  "name": "Prenzlauer Berg",
+                  "weight": 55,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 85,
+                    "location": [13.417166, 52.528458],
+                    "type": "turn",
+                    "bearing_before": 28,
+                    "modifier": "right"
+                  }
+                },
+                {
+                  "intersections": [
+                    {
+                      "out": 1,
+                      "in": 2,
+                      "entry": [true, true, false, true],
+                      "location": [13.424993, 52.528068],
+                      "bearings": [60, 150, 255, 345]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false],
+                      "location": [13.425842, 52.527621],
+                      "bearings": [120, 225, 300]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false],
+                      "location": [13.428041, 52.526565],
+                      "bearings": [135, 225, 315]
+                    },
+                    {
+                      "out": 0,
+                      "in": 2,
+                      "entry": [true, true, false],
+                      "location": [13.429315, 52.525737],
+                      "bearings": [135, 225, 315]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry":
+                      "mkr_Iea}pALKDEDCHOL]FO^uA@GTu@La@`A_DJ[pAgCJSlAwBJSf@{@b@w@dAqBHQZq@LMLKRI",
+                  "duration": 47.9,
+                  "distance": 509.2,
+                  "name": "Friedenstraße",
+                  "weight": 47.9,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 153,
+                    "location": [13.424993, 52.528068],
+                    "type": "turn",
+                    "bearing_before": 67,
+                    "modifier": "right"
+                  }
+                },
+                {
+                  "intersections": [
+                    {
+                      "out": 1,
+                      "in": 2,
+                      "entry": [true, true, false],
+                      "location": [13.430405, 52.524964],
+                      "bearings": [135, 180, 345]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry":
+                      "_xq_Iac~pAFAL?J@HBFBp@XPHh@TTJNFTRNFd@N\\HF@J@J@",
+                  "duration": 20.9,
+                  "distance": 196.4,
+                  "name": "Platz der Vereinten Nationen",
+                  "weight": 20.9,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 174,
+                    "location": [13.430405, 52.524964],
+                    "type": "new name",
+                    "bearing_before": 163,
+                    "modifier": "straight"
+                  }
+                },
+                {
+                  "intersections": [
+                    {
+                      "out": 3,
+                      "in": 0,
+                      "lanes": [
+                        {
+                          "valid": false,
+                          "indications": ["left"]
+                        },
+                        {
+                          "valid": false,
+                          "indications": ["straight", "left"]
+                        },
+                        {
+                          "valid": false,
+                          "indications": ["straight"]
+                        },
+                        {
+                          "valid": true,
+                          "indications": ["straight", "right"]
+                        }
+                      ],
+                      "entry": [false, false, true, true],
+                      "location": [13.429678, 52.523269],
+                      "bearings": [0, 90, 180, 270]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry": "mmq_Io~}pA@V?N@rA@dB",
+                  "duration": 6.9,
+                  "distance": 76.1,
+                  "name": "Platz der Vereinten Nationen",
+                  "weight": 6.9,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 267,
+                    "location": [13.429678, 52.523269],
+                    "type": "continue",
+                    "bearing_before": 184,
+                    "modifier": "right"
+                  }
+                },
+                {
+                  "intersections": [
+                    {
+                      "in": 0,
+                      "entry": [true],
+                      "location": [13.428554, 52.523239],
+                      "bearings": [88]
+                    }
+                  ],
+                  "driving_side": "right",
+                  "geometry": "gmq_Imw}pA",
+                  "duration": 0,
+                  "distance": 0,
+                  "name": "Platz der Vereinten Nationen",
+                  "weight": 0,
+                  "mode": "driving",
+                  "maneuver": {
+                    "bearing_after": 0,
+                    "bearing_before": 268,
+                    "type": "arrive",
+                    "location": [13.428554, 52.523239]
+                  }
+                }
+              ],
+              "weight": 363.5,
+              "distance": 2839.1,
+              "summary": "Torstraße, Friedenstraße",
+              "duration": 363.5
+            }
+          ],
+          "weight_name": "routability",
+          "weight": 616.2,
+          "distance": 4723.8,
+          "duration": 615.0
+        }
+      ]
+    };
+    Road road = await parseRoad(ParserRoadComputeArg(
+      jsonRoad: responseApi,
+      langCode: "en",
+    ));
+    expect(road.distance, 4.7238);
+    expect(road.duration, 615.0);
+    expect(road.polyline, null);
+    expect(road.polylineEncoded, null);
   });
   test('test RoadStep', () {
     final json = {
@@ -5158,6 +5883,743 @@ const _response2ndRoute = {
       "distance": 13.456381067,
       "name": "Töpferweg",
       "location": [8.298834, 49.977417]
+    }
+  ]
+};
+
+const _responseWithoutGeometry = {
+  "code": "Ok",
+  "routes": [
+    {
+      "legs": [
+        {
+          "steps": [
+            {
+              "geometry":
+                  "mfp_I__vpAWBSBE?C?[BUBuALI@O@wAJK@UBMMC?AAKAe@FyBTC@E?IDIDA@M@]BUBSBA?E@E@A@IFWBG@C?WBm@FG@I@aBNG@i@FO@OBaBNUBmAFc@@}@Fu@DG?a@B[@qAF}@JA?[D_E`@SBO@ODA@UDA?ODE@GBC?uBNE?OAKC",
+              "maneuver": {
+                "bearing_after": 355,
+                "bearing_before": 0,
+                "location": [13.388798, 52.517033],
+                "type": "depart"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Friedrichstraße",
+              "intersections": [
+                {
+                  "out": 0,
+                  "entry": [true],
+                  "bearings": [355],
+                  "location": [13.388798, 52.517033]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, false, false, true],
+                  "bearings": [0, 90, 180, 270],
+                  "location": [13.38878, 52.517149]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false, true],
+                  "bearings": [0, 90, 180, 270],
+                  "location": [13.388643, 52.518027]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false, true, false],
+                  "bearings": [30, 90, 180, 270, 315],
+                  "location": [13.388544, 52.518716]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [true, false, true, false],
+                  "bearings": [0, 165, 180, 285],
+                  "location": [13.388255, 52.520395]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false, true],
+                  "bearings": [0, 45, 180, 225],
+                  "location": [13.388022, 52.521758]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [true, false, true],
+                  "bearings": [0, 180, 225],
+                  "location": [13.387885, 52.522524]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [0, 90, 180],
+                  "location": [13.387799, 52.523401]
+                },
+                {
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": ["none"]
+                    },
+                    {
+                      "valid": false,
+                      "indications": ["left"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight"]
+                    }
+                  ],
+                  "out": 0,
+                  "in": 1,
+                  "entry": [true, false, true],
+                  "bearings": [0, 180, 270],
+                  "location": [13.387748, 52.523877]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [0, 90, 180],
+                  "location": [13.3877, 52.524433]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [true, false, false, true],
+                  "bearings": [105, 165, 300, 345],
+                  "location": [13.387337, 52.526239]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, false, false, false],
+                  "bearings": [0, 105, 165, 255],
+                  "location": [13.387283, 52.526386]
+                }
+              ],
+              "weight": 138.3,
+              "duration": 135.5,
+              "distance": 1136.9
+            },
+            {
+              "geometry":
+                  "yer_IeuupAC_@AI]mCCUE[AK[iCUaBAMAMSsAE[k@sE_@_DAMACAKAOIk@AKQuACOQyAG[Gc@]wBw@aFKu@y@oFCMAOIm@?K",
+              "maneuver": {
+                "bearing_after": 71,
+                "bearing_before": 8,
+                "location": [13.387228, 52.527168],
+                "modifier": "right",
+                "type": "turn"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Torstraße",
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [true, false, true, true],
+                  "bearings": [75, 195, 255, 330],
+                  "location": [13.387228, 52.527168]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [true, false, true],
+                  "bearings": [75, 255, 345],
+                  "location": [13.389147, 52.527549]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [true, false, true],
+                  "bearings": [75, 255, 330],
+                  "location": [13.391396, 52.528032]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [75, 165, 255],
+                  "location": [13.392425, 52.528233]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false, true],
+                  "bearings": [75, 120, 255, 330],
+                  "location": [13.393814, 52.528526]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [true, false, true],
+                  "bearings": [75, 255, 345],
+                  "location": [13.395724, 52.528996]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false, true],
+                  "bearings": [90, 180, 255, 345],
+                  "location": [13.397565, 52.529429]
+                }
+              ],
+              "weight": 124.6,
+              "duration": 124.6,
+              "distance": 750.1
+            },
+            {
+              "geometry": "}sr_IevwpA",
+              "maneuver": {
+                "bearing_after": 0,
+                "bearing_before": 86,
+                "location": [13.39763, 52.529432],
+                "type": "arrive"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Torstraße",
+              "intersections": [
+                {
+                  "in": 0,
+                  "entry": [true],
+                  "bearings": [266],
+                  "location": [13.39763, 52.529432]
+                }
+              ],
+              "weight": 0,
+              "duration": 0,
+              "distance": 0
+            }
+          ],
+          "summary": "Friedrichstraße, Torstraße",
+          "weight": 262.9,
+          "duration": 260.1,
+          "distance": 1887
+        },
+        {
+          "steps": [
+            {
+              "geometry":
+                  "}sr_IevwpAAQ?KIuDQmHEuB@U@U?OCq@?I?IASAg@ASMaF?OAi@?c@@c@Du@r@cH@U@I@G@I?G~@kJRyBf@uE@KFi@@KPuABMFc@D[@MT_C@QJ{@Ny@Ha@RiAfBuJF]DOh@yAHSf@aADIR_@",
+              "maneuver": {
+                "bearing_after": 85,
+                "bearing_before": 0,
+                "location": [13.39763, 52.529432],
+                "type": "depart"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Torstraße",
+              "intersections": [
+                {
+                  "out": 0,
+                  "entry": [true],
+                  "bearings": [85],
+                  "location": [13.39763, 52.529432]
+                },
+                {
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": ["left"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight", "right"]
+                    }
+                  ],
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false, false],
+                  "bearings": [90, 150, 270, 330],
+                  "location": [13.401337, 52.529605]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, false, true],
+                  "bearings": [90, 165, 285],
+                  "location": [13.401541, 52.529618]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [105, 195, 285],
+                  "location": [13.405456, 52.529405]
+                },
+                {
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": ["left"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight", "right"]
+                    }
+                  ],
+                  "out": 1,
+                  "in": 3,
+                  "entry": [true, true, true, false],
+                  "bearings": [30, 105, 210, 285],
+                  "location": [13.409405, 52.528711]
+                },
+                {
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight", "right"]
+                    }
+                  ],
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [105, 165, 285],
+                  "location": [13.409967, 52.528591]
+                },
+                {
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight", "right"]
+                    }
+                  ],
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, false, false, false],
+                  "bearings": [105, 165, 285, 330],
+                  "location": [13.410146, 52.52855]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [120, 210, 285],
+                  "location": [13.411852, 52.528201]
+                }
+              ],
+              "weight": 203.400000000,
+              "duration": 203.400000000,
+              "distance": 1275.6
+            },
+            {
+              "geometry": "gdr_Iie{pAJS@C@A@CJSWWEECEECOQ",
+              "maneuver": {
+                "bearing_after": 133,
+                "bearing_before": 133,
+                "location": [13.415405, 52.526922],
+                "modifier": "left",
+                "type": "turn"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "",
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": ["left"]
+                    },
+                    {
+                      "valid": false,
+                      "indications": ["left"]
+                    },
+                    {
+                      "valid": false,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight", "right"]
+                    }
+                  ],
+                  "out": 1,
+                  "in": 3,
+                  "entry": [false, true, true, false],
+                  "bearings": [30, 135, 210, 315],
+                  "location": [13.415405, 52.526922]
+                },
+                {
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": ["left"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["left"]
+                    },
+                    {
+                      "valid": false,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": false,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": false,
+                      "indications": ["straight"]
+                    }
+                  ],
+                  "out": 0,
+                  "in": 3,
+                  "entry": [true, true, false, false],
+                  "bearings": [30, 135, 210, 315],
+                  "location": [13.415657, 52.52677]
+                }
+              ],
+              "weight": 12,
+              "duration": 12,
+              "distance": 60.6
+            },
+            {
+              "geometry": "aer_Iuh{pAe@a@CCUQaCkB{@y@GESO",
+              "maneuver": {
+                "bearing_after": 26,
+                "bearing_before": 32,
+                "location": [13.415945, 52.527047],
+                "modifier": "straight",
+                "type": "new name"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Prenzlauer Allee",
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": ["left"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight"]
+                    }
+                  ],
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, false, false, true],
+                  "bearings": [30, 120, 210, 315],
+                  "location": [13.415945, 52.527047]
+                }
+              ],
+              "weight": 18.2,
+              "duration": 18.2,
+              "distance": 177.6
+            },
+            {
+              "geometry":
+                  "{mr_Iip{pA?_@?C?C?WIoCGqCAK?[MaEASMgDAi@AQ@YBKf@_ENg@D]T{ABIHm@FY@GBUJk@@IHcA?c@?QAQG]",
+              "maneuver": {
+                "bearing_after": 85,
+                "bearing_before": 28,
+                "location": [13.417166, 52.528458],
+                "modifier": "right",
+                "type": "turn"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Prenzlauer Berg",
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [true, true, false, false],
+                  "bearings": [30, 90, 210, 315],
+                  "location": [13.417166, 52.528458]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [false, true, true, false],
+                  "bearings": [45, 120, 225, 285],
+                  "location": [13.423592, 52.528206]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [true, true, false, false],
+                  "bearings": [45, 105, 210, 300],
+                  "location": [13.423868, 52.528136]
+                }
+              ],
+              "weight": 57,
+              "duration": 57,
+              "distance": 548.7
+            },
+            {
+              "geometry":
+                  "mkr_Iea}pAJKDC@ADCHOL]FOFUT{@BKTu@La@\\gANg@L_@DOJ[~@kBP[JSXg@^q@R]Ta@HQR]b@y@^s@Xg@JQHQP_@HQLMLKRI",
+              "maneuver": {
+                "bearing_after": 151,
+                "bearing_before": 67,
+                "location": [13.424993, 52.528068],
+                "modifier": "right",
+                "type": "turn"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Friedenstraße",
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [true, true, false, true],
+                  "bearings": [60, 150, 255, 345],
+                  "location": [13.424993, 52.528068]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [120, 225, 300],
+                  "location": [13.425818, 52.52763]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [135, 225, 315],
+                  "location": [13.428041, 52.526565]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [135, 225, 315],
+                  "location": [13.429337, 52.525737]
+                }
+              ],
+              "weight": 52.400000000,
+              "duration": 52.400000000,
+              "distance": 510.1
+            },
+            {
+              "geometry": "_xq_Iac~pAFAL?J@HBFBr@XNH^NHDTJNFTRRJd@LXFB@B?VB",
+              "maneuver": {
+                "bearing_after": 174,
+                "bearing_before": 163,
+                "location": [13.430405, 52.524964],
+                "modifier": "straight",
+                "type": "new name"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Platz der Vereinten Nationen",
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [true, true, false],
+                  "bearings": [135, 180, 345],
+                  "location": [13.430405, 52.524964]
+                }
+              ],
+              "weight": 20.6,
+              "duration": 20.6,
+              "distance": 196.6
+            },
+            {
+              "geometry": "mmq_Io~}pA@V?N?F@jA@dB",
+              "maneuver": {
+                "bearing_after": 267,
+                "bearing_before": 189,
+                "location": [13.429678, 52.523269],
+                "modifier": "right",
+                "type": "continue"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Platz der Vereinten Nationen",
+              "intersections": [
+                {
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": ["left"]
+                    },
+                    {
+                      "valid": false,
+                      "indications": ["straight", "left"]
+                    },
+                    {
+                      "valid": false,
+                      "indications": ["straight"]
+                    },
+                    {
+                      "valid": true,
+                      "indications": ["straight", "right"]
+                    }
+                  ],
+                  "out": 3,
+                  "in": 0,
+                  "entry": [false, false, true, true],
+                  "bearings": [15, 90, 180, 270],
+                  "location": [13.429678, 52.523269]
+                }
+              ],
+              "weight": 6.9,
+              "duration": 6.9,
+              "distance": 76.4
+            },
+            {
+              "geometry": "gmq_Imw}pA",
+              "maneuver": {
+                "bearing_after": 0,
+                "bearing_before": 268,
+                "location": [13.428554, 52.523239],
+                "type": "arrive"
+              },
+              "mode": "driving",
+              "driving_side": "right",
+              "name": "Platz der Vereinten Nationen",
+              "intersections": [
+                {
+                  "in": 0,
+                  "entry": [true],
+                  "bearings": [88],
+                  "location": [13.428554, 52.523239]
+                }
+              ],
+              "weight": 0,
+              "duration": 0,
+              "distance": 0
+            }
+          ],
+          "summary": "Torstraße, Friedenstraße",
+          "weight": 370.5,
+          "duration": 370.5,
+          "distance": 2845.5
+        }
+      ],
+      "weight_name": "routability",
+      "weight": 633.4,
+      "duration": 630.6,
+      "distance": 4732.5
+    }
+  ],
+  "waypoints": [
+    {
+      "hint":
+          "XP8JgPUvmoUXAAAABQAAAAAAAAAgAAAAIXRPQYXNK0AAAAAAcPePQQsAAAADAAAAAAAAABAAAAC8-QAA_kvMAKlYIQM8TMwArVghAwAA7wqGF9Uq",
+      "distance": 4.231521214,
+      "name": "Friedrichstraße",
+      "location": [13.388798, 52.517033]
+    },
+    {
+      "hint":
+          "7jfdgR8ZiocGAAAACgAAAAAAAAB3AAAAppONQOodwkAAAAAA8TeEQgYAAAAKAAAAAAAAAHcAAAC8-QAAfm7MABiJIQOCbswA_4ghAwAAXwWGF9Uq",
+      "distance": 2.795148358,
+      "name": "Torstraße",
+      "location": [13.39763, 52.529432]
+    },
+    {
+      "hint":
+          "WCoYgP___38fAAAAUQAAACYAAAAeAAAAeosKQlNOX0Jq6iZCjsMGQh8AAABRAAAAJgAAAB4AAAC8-QAASufMAOdwIQNL58wA03AhAwQAvxCGF9Uq",
+      "distance": 2.226580806,
+      "name": "Platz der Vereinten Nationen",
+      "location": [13.428554, 52.523239]
+    }
+  ]
+};
+
+const _responseTripWithoutGeometry = {
+  "code": "Ok",
+  "trips": [
+    {
+      "legs": [
+        {
+          "steps": [],
+          "summary": "",
+          "weight": 263.2,
+          "duration": 260.4,
+          "distance": 1887
+        },
+        {
+          "steps": [],
+          "summary": "",
+          "weight": 370.5,
+          "duration": 370.5,
+          "distance": 2845.5
+        },
+        {
+          "steps": [],
+          "summary": "",
+          "weight": 339.8,
+          "duration": 338.6,
+          "distance": 3279.8
+        }
+      ],
+      "weight_name": "routability",
+      "weight": 973.5,
+      "duration": 969.5,
+      "distance": 8012.3
+    }
+  ],
+  "waypoints": [
+    {
+      "waypoint_index": 0,
+      "trips_index": 0,
+      "hint":
+          "TP8JgEs9moUXAAAABQAAAAAAAAAgAAAAIXRPQYXNK0AAAAAAcPePQQsAAAADAAAAAAAAABAAAABo-gAA_kvMAKlYIQM8TMwArVghAwAA7wogccr9",
+      "distance": 4.231521214,
+      "name": "Friedrichstraße",
+      "location": [13.388798, 52.517033]
+    },
+    {
+      "waypoint_index": 1,
+      "trips_index": 0,
+      "hint":
+          "fTvdgTsuiocGAAAACgAAAAAAAAB3AAAAppONQOodwkAAAAAA8TeEQgYAAAAKAAAAAAAAAHcAAABo-gAAfm7MABiJIQOCbswA_4ghAwAAXwUgccr9",
+      "distance": 2.795148358,
+      "name": "Torstraße",
+      "location": [13.39763, 52.529432]
+    },
+    {
+      "waypoint_index": 2,
+      "trips_index": 0,
+      "hint":
+          "WyoYgP___38fAAAAUQAAACYAAAAeAAAAeosKQlNOX0Jq6iZCjsMGQh8AAABRAAAAJgAAAB4AAABo-gAASufMAOdwIQNL58wA03AhAwQAvxAgccr9",
+      "distance": 2.226580806,
+      "name": "Platz der Vereinten Nationen",
+      "location": [13.428554, 52.523239]
     }
   ]
 };


### PR DESCRIPTION
Currently the `Road.fromOSRMJson()` function assumes that the `geometry` fields of responses is always present, and so throws an error when the overview parameter is set to none in the `OSRMManager.getRoad()` or `OSRMManager.getTrip()` functions.
This fix is just to do a null check before trying to set the `polyline` member variable.
Also added some unit tests to verify the correct functionality, and updated dependencies to get the unit tests running again, `http_mock_adapter` was throwing an error.