### PR TITLE
road type fix

### DIFF
--- a/lib/src/osrm_manager.dart
+++ b/lib/src/osrm_manager.dart
@@ -2,13 +2,12 @@ import 'dart:math';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:routing_client_dart/src/models/lng_lat.dart';
 import 'package:routing_client_dart/src/models/lng_lat_radian.dart';
 import 'package:routing_client_dart/src/models/math_utils.dart';
 import 'package:routing_client_dart/src/models/osrm_mixin.dart';
-import 'package:routing_client_dart/src/utilities/computes_utilities.dart';
-
-import 'package:routing_client_dart/src/models/lng_lat.dart';
 import 'package:routing_client_dart/src/models/road.dart';
+import 'package:routing_client_dart/src/utilities/computes_utilities.dart';
 import 'package:routing_client_dart/src/utilities/utils.dart';
 
 /// [OSRMManager]
@@ -54,13 +53,14 @@ class OSRMManager with OSRMHelper {
   /// in case of any problem
   Future<Road> getRoad({
     required List<LngLat> waypoints,
-    RoadType roadType = RoadType.car,
+    RoadType? roadType,
     bool alternative = false,
     bool steps = true,
     Overview overview = Overview.full,
     Geometries geometries = Geometries.geojson,
     Languages language = Languages.en,
   }) async {
+    roadType ??= this.roadType;
     String path = generatePath(
       server,
       waypoints.toWaypoints(),
@@ -87,7 +87,7 @@ class OSRMManager with OSRMHelper {
   }
 
   /// [getTrip]
-  /// 
+  ///
   /// this method used to get route from trip service api
   /// used if you have more that 10 waypoint to generate route will more accurate
   /// than [getRoad].
@@ -96,7 +96,7 @@ class OSRMManager with OSRMHelper {
   /// [source] and [destination] must be provided.
   Future<Road> getTrip({
     required List<LngLat> waypoints,
-    RoadType roadType = RoadType.car,
+    RoadType? roadType,
     bool roundTrip = true,
     SourceGeoPointOption source = SourceGeoPointOption.any,
     DestinationGeoPointOption destination = DestinationGeoPointOption.any,
@@ -105,6 +105,8 @@ class OSRMManager with OSRMHelper {
     Geometries geometries = Geometries.polyline,
     Languages language = Languages.en,
   }) async {
+    roadType ??= this.roadType;
+
     if (!roundTrip &&
         (source == SourceGeoPointOption.any ||
             destination == DestinationGeoPointOption.any)) {


### PR DESCRIPTION
This aims to fix [#11](https://github.com/liodali/OSM-Routing-Client-Dart/issues/11)

`roadType` was being overridden to `car`, no matter what option was selected.