### PR TITLE
Fix routing request error by encoding JSON payload in Dio request

### DIFF
--- a/lib/src/models/valhalla/valhalla_response.dart
+++ b/lib/src/models/valhalla/valhalla_response.dart
@@ -124,7 +124,7 @@ class Maneuver {
   final String? verbalPostTransitionInstruction;
   final double time;
   final double length;
-  final int cost;
+  final double cost;
   final int beginShapeIndex;
   final int endShapeIndex;
   final bool? rough;
@@ -179,7 +179,7 @@ class Summary {
   final double maxLon;
   final double time;
   final double length;
-  final int cost;
+  final double cost;
 
   const Summary._({
     required this.hasTimeRestrictions,

--- a/lib/src/routes_services/valhalla_service.dart
+++ b/lib/src/routes_services/valhalla_service.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:routing_client_dart/src/models/request_helper.dart';
 import 'package:routing_client_dart/src/models/route.dart';
 import 'package:routing_client_dart/src/models/valhalla/valhalla_response.dart';
@@ -12,7 +14,7 @@ class ValhallaRoutingService extends RoutingService {
     final jsonHeaderRequest = request.encodeHeader();
     final response = await dio.get(
       osmValhallaServer,
-      queryParameters: {'json': jsonHeaderRequest},
+      queryParameters: {'json': json.encode(jsonHeaderRequest)},
     );
     if (response.statusCode != null && response.statusCode! > 299 ||
         response.statusCode! < 200) {


### PR DESCRIPTION
I encountered an issue when trying to request routing using Valhalla, resulting in the following error:
DioException [bad response]: This exception was thrown because the response has a status code of 400 and RequestOptions.validateStatus was configured to throw for this status code.

After adding a Dio interceptor on RoutingService, I was able to capture the following API response:
{
  "error_code": 110,
  "error": "Insufficiently specified required parameter 'locations'",
  "status_code": 400,
  "status": "Bad Request"
}

Upon investigating the Valhalla documentation : https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference, I noticed that the locations payload must be included inside /route?json="here" as a JSON string.
To resolve this, I added json.encode() to the payload, and the request now works as expected.

Additionally, I made a small adjustment to the API response from Valhalla by changing the cost key value from an integer to a double to ensure consistency with the response format provided by Valhalla.
